### PR TITLE
feat: add allowed pivots

### DIFF
--- a/docs/wiki/anime/index.md
+++ b/docs/wiki/anime/index.md
@@ -39,6 +39,10 @@ For example, Bakemonogatari is an anime production with five opening sequences a
 * series
 * studios
 
+## Allowed Pivots
+
+* animeresource
+
 ## Endpoints
 
 **[Anime Destroy](/wiki/anime/destroy/)**

--- a/docs/wiki/artist/index.md
+++ b/docs/wiki/artist/index.md
@@ -17,7 +17,6 @@ For example, Chiwa Saitou is the musical performer of the Bakemonogatari OP1 the
 | id         | Integer | No       | Yes     | The primary key of the resource                                |
 | name       | String  | No       | Yes     | The primary title of the artist                                |
 | slug       | String  | No       | Yes     | The URL slug & route key of the resource                       |
-| as         | String  | No       | Yes     | Used to distinguish a performance by alias, character or group |
 | created_at | Date    | No       | No      | The date that the resource was created                         |
 | updated_at | Date    | No       | No      | The date that the resource was last modified                   |
 | deleted_at | Date    | Yes      | No      | The date that the resource was deleted                         |
@@ -31,6 +30,12 @@ For example, Chiwa Saitou is the musical performer of the Bakemonogatari OP1 the
 * songs
 * songs.animethemes
 * songs.animethemes.anime
+
+## Allowed Pivots
+
+* artistmember
+* artistresource
+* artistsong
 
 ## Endpoints
 

--- a/docs/wiki/resource/index.md
+++ b/docs/wiki/resource/index.md
@@ -18,7 +18,6 @@ For example, the Bakemonogatari anime has MyAnimeList, AniList and AniDB resourc
 | link        | String  | Yes      | Yes     | The URL of the external site                                       |
 | external_id | Integer | Yes      | Yes     | The primary key of the resource in the external site               |
 | site        | Enum    | Yes      | Yes     | The external site that the resource belongs to [Official Website, Twitter, AniDB, Anilist, Anime-Planet, Anime News Network, Kitsu, MyAnimeList, Wikipedia] |
-| as          | String  | Yes      | Yes     | Used to distinguish resources that map to the same artist or anime |
 | created_at  | Date    | No       | No      | The date that the resource was created                             |
 | updated_at  | Date    | No       | No      | The date that the resource was last modified                       |
 | deleted_at  | Date    | Yes      | No      | The date that the resource was deleted                             |
@@ -28,6 +27,12 @@ For example, the Bakemonogatari anime has MyAnimeList, AniList and AniDB resourc
 * anime
 * artists
 * studios
+
+## Allowed Pivots
+
+* animeresource
+* artistresource
+* studioresource
 
 ## Endpoints
 

--- a/docs/wiki/song/index.md
+++ b/docs/wiki/song/index.md
@@ -12,20 +12,23 @@ For example, Staple Stable is the song for the Bakemonogatari OP1 AnimeTheme.
 
 ## Fields
 
-|    Name    |  Type   | Nullable | Default | Description                                                    |
-| :--------: | :-----: | :------: | :-----: | :------------------------------------------------------------- |
-| id         | Integer | No       | Yes     | The primary key of the resource                                |
-| title      | String  | Yes      | Yes     | The name of the composition                                    |
-| as         | String  | Yes      | Yes     | Used to distinguish a performance by alias, character or group |
-| created_at | Date    | No       | No      | The date that the resource was created                         |
-| updated_at | Date    | No       | No      | The date that the resource was last modified                   |
-| deleted_at | Date    | Yes      | No      | The date that the resource was deleted                         |
+|    Name    |  Type   | Nullable | Default | Description                                  |
+| :--------: | :-----: | :------: | :-----: | :------------------------------------------- |
+| id         | Integer | No       | Yes     | The primary key of the resource              |
+| title      | String  | Yes      | Yes     | The name of the composition                  |
+| created_at | Date    | No       | No      | The date that the resource was created       |
+| updated_at | Date    | No       | No      | The date that the resource was last modified |
+| deleted_at | Date    | Yes      | No      | The date that the resource was deleted       |
 
 ## Allowed Include Paths
 
 * animethemes
 * animethemes.anime
 * artists
+
+## Allowed Pivots
+
+* artistsong
 
 ## Endpoints
 

--- a/docs/wiki/studio/index.md
+++ b/docs/wiki/studio/index.md
@@ -27,6 +27,10 @@ For example, Shaft is the studio that produced the anime Bakemonogatari.
 * images
 * resources
 
+## Allowed Pivots
+
+* studioresource
+
 ## Endpoints
 
 **[Studio Destroy](/wiki/studio/destroy/)**


### PR DESCRIPTION
Pivots are now treated as allowed includes when loaded rather than resolving specific pivot fields on the parent resource.